### PR TITLE
Fix schedule

### DIFF
--- a/pages/schedule.qmd
+++ b/pages/schedule.qmd
@@ -11,9 +11,9 @@ library(kableExtra)
 cols_to_display <- c("time", "type", "author", "title")
 # section headers
 ds <- c(
-    "Wed. - Oct. 17, '25",
-    "Thu. - Oct. 18, '25",
-    "Fri. - Oct. 19, '25")
+    "Wed. - Sep. 17, '25",
+    "Thu. - Sep. 18, '25",
+    "Fri. - Sep. 19, '25")
 is <- split(seq(nrow(df)), df$day)
 # column widths
 ws <- paste0(100/length(cols_to_display), "%")


### PR DESCRIPTION
Hi @rcastelo, this PR corrects the month on the schedule page (from Oct to Sep) and removes the 'Info' column, which currently contains only NAs. The 'Info' column could be used post-conference to link to video content.